### PR TITLE
Update BEMAN_STANDARD: add CMAKE.SKIP_EXAMPLES

### DIFF
--- a/docs/BEMAN_STANDARD.md
+++ b/docs/BEMAN_STANDARD.md
@@ -204,6 +204,17 @@ if(BEMAN_<short_name>_BUILD_TESTING)
 endif()
 ```
 
+**[CMAKE.SKIP_EXAMPLES]** RECOMMENDATION: The root `CMakeLists.txt` should not build examples and their dependencies when [PROJECT_IS_TOP_LEVEL](https://cmake.org/cmake/help/latest/variable/PROJECT_IS_TOP_LEVEL.html) is not set. Examples should not be installed when current library is used as an dependency.
+
+Use the following style:
+
+```CMake
+# <repo>/CMakeLists.txt
+# ...
+if(PROJECT_IS_TOP_LEVEL)
+    add_subdirectory(examples)
+endif()
+```
 **[CMAKE.AVOID_PASSTHROUGHS]** RECOMMENDATION: Avoid `CMakeLists.txt` files
 consisting of a single `add_subdirectory` call.
 
@@ -321,6 +332,7 @@ directory. Each project must have at least one relevant example.
 Examples:
 
 ```shell
+
 examples
 ├── CMakeLists.txt
 ├── identity_as_default_projection.cpp

--- a/docs/BEMAN_STANDARD.md
+++ b/docs/BEMAN_STANDARD.md
@@ -222,7 +222,7 @@ option(
 
 # ...
 if(BEMAN_<short_name>_BUILD_EXAMPLES)
-  add_subdirectory(tests)
+  add_subdirectory(examples)
 endif()
 ```
 

--- a/docs/BEMAN_STANDARD.md
+++ b/docs/BEMAN_STANDARD.md
@@ -343,7 +343,6 @@ directory. Each project must have at least one relevant example.
 Examples:
 
 ```shell
-
 examples
 ├── CMakeLists.txt
 ├── identity_as_default_projection.cpp

--- a/docs/BEMAN_STANDARD.md
+++ b/docs/BEMAN_STANDARD.md
@@ -204,7 +204,7 @@ if(BEMAN_<short_name>_BUILD_TESTING)
 endif()
 ```
 
-**[CMAKE.SKIP_EXAMPLES]** RECOMMENDATION: The root `CMakeLists.txt` should not build examples and their dependencies when `BEMAN_<short_name>_BUILD_EXAMPLEs` is set to `OFF`. The option is prefixed with the project so that projects can compose. Turning on examples for the top level project should not turn on examples for dependencies. 
+**[CMAKE.SKIP_EXAMPLES]** RECOMMENDATION: The root `CMakeLists.txt` should not build examples and their dependencies when `BEMAN_<short_name>_BUILD_EXAMPLES` is set to `OFF`. The option is prefixed with the project so that projects can compose. Turning on examples for the top level project should not turn on examples for dependencies. 
 
 Use the following style:
 

--- a/docs/BEMAN_STANDARD.md
+++ b/docs/BEMAN_STANDARD.md
@@ -204,17 +204,28 @@ if(BEMAN_<short_name>_BUILD_TESTING)
 endif()
 ```
 
-**[CMAKE.SKIP_EXAMPLES]** RECOMMENDATION: The root `CMakeLists.txt` should not build examples and their dependencies when [PROJECT_IS_TOP_LEVEL](https://cmake.org/cmake/help/latest/variable/PROJECT_IS_TOP_LEVEL.html) is not set. Examples should not be installed when current library is used as an dependency.
+**[CMAKE.SKIP_EXAMPLES]** RECOMMENDATION: The root `CMakeLists.txt` should not build examples and their dependencies when `BEMAN_<short_name>_BUILD_EXAMPLEs` is set to `OFF`. The option is prefixed with the project so that projects can compose. Turning on examples for the top level project should not turn on examples for dependencies. 
 
 Use the following style:
 
 ```CMake
 # <repo>/CMakeLists.txt
 # ...
-if(PROJECT_IS_TOP_LEVEL)
-    add_subdirectory(examples)
+option(
+    BEMAN_<short_name>_BUILD_EXAMPLES
+    "Enable building examples. Default: ON. Values: { ON, OFF }."
+    ${PROJECT_IS_TOP_LEVEL}
+)
+
+# add actual code to be build here
+...
+
+# ...
+if(BEMAN_<short_name>_BUILD_EXAMPLES)
+  add_subdirectory(tests)
 endif()
 ```
+
 **[CMAKE.AVOID_PASSTHROUGHS]** RECOMMENDATION: Avoid `CMakeLists.txt` files
 consisting of a single `add_subdirectory` call.
 


### PR DESCRIPTION
Add CMAKE.SKIP_EXAMPLES, option which allows to skip building examples. We need this in some contexts where we just want to deliver a header-only library (e.g.[ integrate iterator_interface on Compiler Explorer](https://github.com/changkhothuychung/infra/blob/96a5a7d3292b428fb4a55f90cf14008e2d94ac3d/bin/yaml/libraries.yaml#L1037)).