### PR TITLE
Update BEMAN_STANDARD: rename flag under CMAKE.SKIP_TESTS

### DIFF
--- a/docs/BEMAN_STANDARD.md
+++ b/docs/BEMAN_STANDARD.md
@@ -175,7 +175,7 @@ add_executable(beman.smart_pointer.tests.roundtrip)
 `<library_name>Config.cmake` must be created which exports a
 `beman::<short_name>` target.
 
-**[CMAKE.SKIP_TESTS]** RECOMMENDATION: The root `CMakeLists.txt` should not build tests and their dependencies when `BEMAN_<short_name>_BUILD_TESTING` is set to `OFF` (see [CTest docs](https://cmake.org/cmake/help/latest/module/CTest.html) - similar to cmake's `BUILD_TESTING`). The option is prefixed with the project so that projects can compose. Turning on testing for the top level project should not turn on testing for dependencies. Since testing is part of the normal development workflow it is appropriate to set the option on by default for the top level project.
+**[CMAKE.SKIP_TESTS]** RECOMMENDATION: The root `CMakeLists.txt` should not build tests and their dependencies when `BEMAN_<short_name>_BUILD_TESTS` is set to `OFF` (see [CTest docs](https://cmake.org/cmake/help/latest/module/CTest.html) - similar to cmake's `BUILD_TESTING`). The option is prefixed with the project so that projects can compose. Turning on testing for the top level project should not turn on testing for dependencies. Since testing is part of the normal development workflow it is appropriate to set the option on by default for the top level project.
 
 Use the following style:
 
@@ -183,12 +183,12 @@ Use the following style:
 # <repo>/CMakeLists.txt
 # ...
 option(
-    BEMAN_<short_name>_BUILD_TESTING
+    BEMAN_<short_name>_BUILD_TESTS
     "Enable building tests and test infrastructure. Default: ON. Values: { ON, OFF }."
     ${PROJECT_IS_TOP_LEVEL}
 )
 
-if(BEMAN_<short_name>_BUILD_TESTING)
+if(BEMAN_<short_name>_BUILD_TESTS)
   FetchContent_Declare(
     googletest
     EXCLUDE_FROM_ALL
@@ -199,7 +199,7 @@ if(BEMAN_<short_name>_BUILD_TESTING)
 endif()
 
 # ...
-if(BEMAN_<short_name>_BUILD_TESTING)
+if(BEMAN_<short_name>_BUILD_TESTS)
   add_subdirectory(tests)
 endif()
 ```


### PR DESCRIPTION
Sync `BEMAN_<short_name>_BUILD_EXAMPLES` and `BEMAN_<short_name>_BUILD_TESTS`.