### PR TITLE
Add rules that mitigate ODR violations

### DIFF
--- a/docs/BEMAN_STANDARD.md
+++ b/docs/BEMAN_STANDARD.md
@@ -461,7 +461,7 @@ not be used directly. Instead use the following approach for feature-dependent
 code generation:
 
 1. Check for availability at CMake time using, for example,
-   `check_cxx_source_compiles`
+   `check_cxx_source_compiles`.
 2. Create a CMake `option` (e.g. `BEMAN_&lt;short_name&gt;_USE_DEDUCING_THIS`)
    with a default value based on detected support.
 3. Generate a `config.hpp` with a `#define` macro set to the selected option.

--- a/docs/BEMAN_STANDARD.md
+++ b/docs/BEMAN_STANDARD.md
@@ -462,7 +462,7 @@ code generation:
 
 1. Check for availability at CMake time using, for example,
    `check_cxx_source_compiles`.
-2. Create a CMake `option` (e.g. `BEMAN_&lt;short_name&gt;_USE_DEDUCING_THIS`)
+2. Create a CMake `option` (e.g. `BEMAN_<short_name>_USE_DEDUCING_THIS`)
    with a default value based on detected support.
 3. Generate a `config.hpp` with a `#define` macro set to the selected option.
 4. Use this macro in place of the feature test macro.


### PR DESCRIPTION
The three rules added here are generally practiced in Beman repositories as a means to mitigate ODR violation risks. While they have been discussed at length in various PRs and issues (see [this comment](https://github.com/bemanproject/exemplar/issues/40#issuecomment-2388995030) for an example), this repeatedly comes up with new folks joining the project.

By encoding this into rules linked to a PR pointing to the rationale the hope is to gain consistency and avoid rehashing the discussions.
