### PR TITLE
Update the Beman Standard: create CHANGELOG related rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## [Unreleased]
+
+### Added
+
+- [LIBRARY_STATUS] N/A - this is a placeholder for the library status.
+- Top-level directory structure for the Beman Project: CHANGELOG.md, CMakelists.txt, LICENSE.txt, and README.md.
+- `docs/` - top level documentation directory: BEMAN_LIBRARY_MATURITY_MODEL.md, BEMAN_STANDARD.md, CODE_OF_CONDUCT.md, FAQ.md, GOVERNANCE.md, and MISSION_STATEMENT.md.
+- `images/` - top level directory for images, such as logos.
+- `presentations/` - top level directory for presentations.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you are looking for ways to contribute code, see the open issues of [bemanpro
 contributors and usually have an assigned mentor. Don't hesitate to post on discourse with any questions.
 
 Please refer to our [code of conduct](/docs/CODE_OF_CONDUCT.md) and the
-[Beman standard](/docs/BEMAN_STANDARD.md) for further information about the community and
+[Beman Standard](/docs/BEMAN_STANDARD.md) for further information about the community and
 development guidelines.
 
 ### FAQ
@@ -38,6 +38,10 @@ Questions? Maybe they have already been answered in our [FAQ](docs/FAQ.md).
 ### About the Name
 
 The Beman project is named in memory of Beman Dawes - co-founder of [Boost](https://www.boost.org).
+
+### Documentation
+
+The Beman Project has a variety of documentation available in the [docs/](./docs/) directory of this repository.
 
 ## Getting Started
 

--- a/docs/BEMAN_STANDARD.md
+++ b/docs/BEMAN_STANDARD.md
@@ -104,8 +104,11 @@ Known exceptions:
 
 ## Top-level
 
-The top-level of a Beman library repository must consist of `CMakeLists.txt`,
+The top-level of a Beman library repository must consist of `CHANGELOG.md`, `CMakeLists.txt`,
 `LICENSE`, and `README.md` files.
+
+**[TOPLEVEL.CHANGELOG]** REQUIREMENT: There must be a `CHANGELOG.md` file at the repository's root
+that describes the changes in each version of the library.
 
 **[TOPLEVEL.CMAKE]** REQUIREMENT: There must be a `CMakeLists.txt` file at the repository's root
 that builds and tests (via. CTest) the library.
@@ -117,6 +120,48 @@ contents of the repository.
 **[TOPLEVEL.README]** REQUIREMENT: There must be a markdown-formatted
 `README.md` file at the repository's root that describes the library, explains how
 to build it, and links to further documentation.
+
+## `CHANGELOG.md`
+
+**[CHANGELOG.TITLE]** REQUIREMENT: The `CHANGELOG.md` must begin with a level 1
+header with the name "Changelog".
+
+**[CHANGELOG.FORMAT]** RECOMMENDATION: The `CHANGELOG.md` should be formatted using the
+[Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.
+
+Use the following style:
+
+```markdown
+## [Unreleased]
+### Added
+- [LIBRARY_STATUS]: Library status updated to [Production ready. Stable API.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#production-ready-stable-api) as it is production ready and the API was adopted into the C++ 26 standard.
+
+### Removed
+- Deprecate `optional::value_or` and `optional::value_or_eval` ...
+
+### Changed
+- `optional::value_or` was replaced with `optional::value_or_eval` ...
+```
+
+**[CHANGELOG.LIBRARY_STATUS]** REQUIREMENT: The `CHANGELOG.md` must contain a line for each previous library status with respect to the [Beman library maturity model](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md).
+
+Use the following style:
+
+```markdown
+- [LIBRARY_STATUS]: Library status updated to [Under development and not yet ready for production use.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#under-development-and-not-yet-ready-for-production-use) as it is not yet ready for production use.
+```
+
+or
+
+```markdown
+- [LIBRARY_STATUS]: Library status updated to [Production ready. API may undergo changes.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#production-ready-api-may-undergo-changes) as it is production ready but the API may undergo changes.
+```
+
+or
+
+```markdown
+- [LIBRARY_STATUS]: Library status updated to [Production ready. Stable API.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#production-ready-stable-api) as it is production ready and the API was adopted into the C++ 26 standard.
+```
 
 ## `README.md`
 
@@ -141,7 +186,7 @@ contain a one- or two-paragraph summary describing the library's purpose.
 [Give *std::optional* Range Support (P3168R1)](https://wg21.link/P3168R1).
 ```
 
-**[README.LIBRARY_STATUS]** REQUIREMENT: Following the implements section and a newline, the `README.md` must indicate the [Beman library maturity model](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md).
+**[README.LIBRARY_STATUS]** REQUIREMENT: Following the implements section and a newline, the `README.md` must indicate the current library status with respect to the [Beman library maturity model](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md). Also, check [CHANGELOG.md#LIBRARY_STATUS](#changelogmd#library_status).
 
 Use the following style:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,9 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 This directory contains information about how the project works, goals, and community information.
 
-* [Mission Statement](MISSION_STATEMENT.md)
-* Beman Project [structure and governance](GOVERNANCE.md)
-* [Frequently Asked Questions](FAQ.md)
+- [BEMAN_LIBRARY_MATURITY_MODEL.md](./BEMAN_LIBRARY_MATURITY_MODEL.md): The `Beman library maturity model` describes the lifetime of libraries inside the Beman Project.
+- [BEMAN_STANDARD.md](./BEMAN_STANDARD.md): The `Beman Standard` is a set of development guidelines for the Beman Project.
+- [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md): The Beman Project's code of conduct.
+- [FAQ.md](./FAQ.md): Frequently asked questions about the Beman Project.
+- [GOVERNANCE.md](./GOVERNANCE.md): The governance document outlines the structure of the Beman Project.
+- [MISSION_STATEMENT.md](./MISSION_STATEMENT.md): The mission statement of the Beman Project.


### PR DESCRIPTION
#77  - as a follow-up for #72 , adding a change log file in each library to capture the history of all previous library status values will solved all corner cases that are unhandled after #72.

Decision made in sync from 2024-12-23.