### PR TITLE
Update The Beman Standard to specify that the changelog file should contain only high level changes

### DIFF
--- a/docs/BEMAN_STANDARD.md
+++ b/docs/BEMAN_STANDARD.md
@@ -138,7 +138,7 @@ Use the following style:
 - [LIBRARY_STATUS]: Library status updated to [Production ready. Stable API.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#production-ready-stable-api) as it is production ready and the API was adopted into the C++ 26 standard.
 
 ### Removed
-- Removed optional range support as Pxyz was reject.
+- Removed optional range support as P3456R3 was rejected.
 
 ### Changed
 - Added optional ref support, as Pabc was proposed for standardization.

--- a/docs/BEMAN_STANDARD.md
+++ b/docs/BEMAN_STANDARD.md
@@ -142,7 +142,7 @@ Use the following style:
 
 ### Changed
 - Added optional ref support, as Pabc was proposed for standardization.
-```
+- Added optional ref support as proposed in P1234R0.
 
 **[CHANGELOG.LIBRARY_STATUS]** REQUIREMENT: The `CHANGELOG.md` must contain a line for each previous library status with respect to the [Beman library maturity model](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md).
 

--- a/docs/BEMAN_STANDARD.md
+++ b/docs/BEMAN_STANDARD.md
@@ -108,7 +108,8 @@ The top-level of a Beman library repository must consist of `CHANGELOG.md`, `CMa
 `LICENSE`, and `README.md` files.
 
 **[TOPLEVEL.CHANGELOG]** REQUIREMENT: There must be a `CHANGELOG.md` file at the repository's root
-that describes the changes in each version of the library.
+that describes the high level changes in each version of the library (e.g., library status change,
+new paper implementation addition, paper implementation removal etc). 
 
 **[TOPLEVEL.CMAKE]** REQUIREMENT: There must be a `CMakeLists.txt` file at the repository's root
 that builds and tests (via. CTest) the library.
@@ -137,10 +138,10 @@ Use the following style:
 - [LIBRARY_STATUS]: Library status updated to [Production ready. Stable API.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#production-ready-stable-api) as it is production ready and the API was adopted into the C++ 26 standard.
 
 ### Removed
-- Deprecate `optional::value_or` and `optional::value_or_eval` ...
+- Removed optional range support as Pxyz was reject.
 
 ### Changed
-- `optional::value_or` was replaced with `optional::value_or_eval` ...
+- Added optional ref support, as Pabc was proposed for standardization.
 ```
 
 **[CHANGELOG.LIBRARY_STATUS]** REQUIREMENT: The `CHANGELOG.md` must contain a line for each previous library status with respect to the [Beman library maturity model](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md).


### PR DESCRIPTION
Follow-up PR for #77.

Update The Beman Standard to specify that the changelog file should contain only high level changes, as discussed per our weekly sync (2025-01-13)

New status:
- CHANGELOG is still a `REQUIREMENT`. Motivation: README.LIBRARY_STATUS is a requirement, and if we want to enforce keeping history of all previous status values in the CHANGELOG, we need to have it present. I'm OK to convert both rules (+ all other related changelog rules) into recommandation, but we miss the "preserve history" point.
- CHANGELOG states only to add high level events, not commit by commit logs.