### PR TITLE
Add recommendation that extensions are prefixed with ext_

### DIFF
--- a/docs/BEMAN_STANDARD.md
+++ b/docs/BEMAN_STANDARD.md
@@ -601,3 +601,5 @@ code generation:
 See
 [beman.iterator_interface](https://github.com/bemanproject/iterator_interface/blob/5e6714e10faa1799723669e04abec6e75adbdb89/CMakeLists.txt#L44)
 for an example.
+
+**[CPP.EXTENSION_IDENTIFIERS]** RECOMMENDATION: For functionality that is not being recommended for standardization, but is an extension provided by the library, its identifiers should be prefixed with `ext_`.


### PR DESCRIPTION
There is precedent for this in beman.iterator_interface's ext_iterator_interface_compat. See commit
b5f416bec26a0cd15df795b5a0379891a6873834 in that repository:

https://github.com/bemanproject/iterator_interface/commit/b5f416bec26a0cd15df795b5a0379891a6873834

This provides an easy way to distinguish between functionality that is and is not being proposed for standardization.