### PR TITLE
Update the Beman Standard: remove changelog

### DIFF
--- a/docs/BEMAN_STANDARD.md
+++ b/docs/BEMAN_STANDARD.md
@@ -108,12 +108,7 @@ Known exceptions:
 
 ## Top-level
 
-The top-level of a Beman library repository must consist of `CHANGELOG.md`, `CMakeLists.txt`,
-`LICENSE`, and `README.md` files.
-
-**[TOPLEVEL.CHANGELOG]** REQUIREMENT: There must be a `CHANGELOG.md` file at the repository's root
-that describes the high level changes in each version of the library (e.g., library status change,
-new paper implementation addition, paper implementation removal etc). 
+The top-level of a Beman library repository must consist of `CMakeLists.txt`, `LICENSE`, and `README.md` files.
 
 **[TOPLEVEL.CMAKE]** REQUIREMENT: There must be a `CMakeLists.txt` file at the repository's root
 that builds and tests (via. CTest) the library.
@@ -125,60 +120,6 @@ contents of the repository.
 **[TOPLEVEL.README]** REQUIREMENT: There must be a markdown-formatted
 `README.md` file at the repository's root that describes the library, explains how
 to build it, and links to further documentation.
-
-## `CHANGELOG.md`
-
-**[CHANGELOG.TITLE]** REQUIREMENT: The `CHANGELOG.md` must begin with a level 1
-header with the name "Changelog".
-
-**[CHANGELOG.FORMAT]** RECOMMENDATION: The `CHANGELOG.md` should be formatted using the
-[Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.
-
-Use the following style:
-
-```markdown
-# Changelog
-
-<!--
-SPDX-License-Identifier: 2.0 license with LLVM exceptions
--->
-
-## [Unreleased]
-### Added
-- [LIBRARY_STATUS]: Library status updated to [Production ready. Stable API.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#production-ready-stable-api) as it is production ready and the API was adopted into the C++ 26 standard.
-
-### Removed
-- Removed optional range support as P3456R3 was rejected.
-
-### Changed
-- Added optional ref support as proposed in P1234R0.
-```
-
-**[CHANGELOG.LIBRARY_STATUS]** REQUIREMENT: The `CHANGELOG.md` must contain a line for each previous library status with respect to the [Beman library maturity model](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md).
-
-Use one of the following styles:
-
-```markdown
-- [LIBRARY_STATUS]: Library status updated to [Under development and not yet ready for production use.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#under-development-and-not-yet-ready-for-production-use): It is not ready yet for production use.
-```
-
-or
-
-```markdown
-- [LIBRARY_STATUS]: Library status updated to [Production ready. API may undergo changes.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#production-ready-api-may-undergo-changes): It is production ready but the API may undergo changes.
-```
-
-or
-
-```markdown
-- [LIBRARY_STATUS]: Library status updated to [Production ready. Stable API.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#production-ready-stable-api): It is production ready and the API was adopted into the C++ 26 standard.
-```
-
-or 
-
-```markdown
-- [LIBRARY_STATUS]: Library status updated to [Retired. No longer maintained or actively developed.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#retired-no-longer-maintained-or-actively-developed): It was rejected from ISO standardization.
-```
 
 ## `README.md`
 
@@ -235,7 +176,7 @@ contain a one line summary describing the library's purpose.
 [Give *std::optional* Range Support (P3168R1)](https://wg21.link/P3168R1).
 ```
 
-**[README.LIBRARY_STATUS]** REQUIREMENT: Following the implements section and a newline, the `README.md` must indicate the current library status with respect to the [Beman library maturity model](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md); also, check [CHANGELOG.md#LIBRARY_STATUS](#changelogmd#library_status). An extra badge must be added to the `README.md` to visually indicate the library status - check `[README.BADGES]`.
+**[README.LIBRARY_STATUS]** REQUIREMENT: Following the implements section and a newline, the `README.md` must indicate the **current** library status with respect to the [Beman library maturity model](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md). An extra badge must be added to the `README.md` to visually indicate the library status (check `[README.BADGES]`). Note: The full library status history can be found in the GitHub release notes.
 
 Use exactly one of the following entries for the status line:
 


### PR DESCRIPTION
#100 - remove changelog 

Propose to replace `library status` line with a `table` with library status history.

Example: [Proposal applied to examplar](https://github.com/bemanproject/exemplar/pull/143/files?short_path=b335630#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5)