### PR TITLE
Update docs: remove incompatible syntax for website docs  import

### DIFF
--- a/docs/BEMAN_LIBRARY_MATURITY_MODEL.md
+++ b/docs/BEMAN_LIBRARY_MATURITY_MODEL.md
@@ -11,30 +11,24 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 ### Under development and not yet ready for production use.
 <img src="../images/logos/beman_logo-beman_library_under_development.png" style="width:5%; height:auto;"> These libraries may deviate from the Beman Standard due to incompleteness, lack of testing, inconsistencies with the specification, or other non-conformances.
 
-> [!CAUTION]
 > They are not recommended for production usage!
 
 ### Production ready. API may undergo changes.
 <img src="../images/logos/beman_logo-beman_library_production_ready_api_may_undergo_changes.png" style="width:5%; height:auto;"> These Beman-compliant libraries are production-ready, fully implementing the target paper with complete testing and documentation. Users should be aware that future API changes are possible and that standardization is not guaranteed.
 
-> [!NOTE]
 > These libraries are recommended for production usage.
 
 ### Production ready. Stable API.
 <img src="../images/logos/beman_logo-beman_library_production_ready_stable_api.png" style="width:5%; height:auto;"> These production-ready libraries offer stable, standardized APIs.  They are part of the C++ Standard and can be used as a polyfill for compilers lacking native support. Note that these libraries will be retired after two standardization cycles (6 years).
 
-> [!NOTE]
 > These libraries are recommended for production usage.
 
 ### Retired. No longer maintained or actively developed.
 <img src="../images/logos/beman_logo-beman_library_retired.png" style="width:5%; height:auto;"> These libraries were archived and no longer maintained. These libraries are not recommended for production use.
 
 
-> [!CAUTION]
 > These libraries are not recommended for production use!
-
-> [!TIP]
->  These libraries were removed from the Beman main distribution, but the initial authors could still support them outside the Beman Project.
+> These libraries were removed from the Beman main distribution, but the initial authors could still support them outside the Beman Project.
 
 
 Transition examples:


### PR DESCRIPTION
This syntax is not supported by the website. As it's not so important and we don't have a solution, I propose to remove this extra annotations. This is a pre-requirement for automatization in website docs import.