### PR TITLE
Update CMAKE.SKIP_* to match Exemplar usage

### DIFF
--- a/docs/BEMAN_STANDARD.md
+++ b/docs/BEMAN_STANDARD.md
@@ -221,7 +221,7 @@ or
 ![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_production_ready_api_may_undergo_changes.svg)
 ```
 
-or 
+or
 
 ```markdown
 ![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_production_ready_stable_api.svg)
@@ -258,7 +258,7 @@ Use exactly one of the following entries for the status line:
 **Status**: [Under development and not yet ready for production use.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#under-development-and-not-yet-ready-for-production-use)
 ```
 
-or 
+or
 
 ```markdown
 **Status**: [Production ready. API may undergo changes.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#production-ready-api-may-undergo-changes)
@@ -270,7 +270,7 @@ or
 **Status**: [Production ready. Stable API.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#production-ready-stable-api)
 ```
 
-or 
+or
 
 ```markdown
 **Status**: [Retired. No longer maintained or actively developed.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#retired-no-longer-maintained-or-actively-developed)
@@ -368,7 +368,7 @@ Use the following style:
 # ...
 option(
     BEMAN_<short_name>_BUILD_TESTS
-    "Enable building tests and test infrastructure. Default: ON. Values: { ON, OFF }."
+    "Enable building tests and test infrastructure. Default: ${PROJECT_IS_TOP_LEVEL}. Values: { ON, OFF }."
     ${PROJECT_IS_TOP_LEVEL}
 )
 # ...
@@ -400,7 +400,7 @@ Use the following style:
 # ...
 option(
     BEMAN_<short_name>_BUILD_EXAMPLES
-    "Enable building examples. Default: ON. Values: { ON, OFF }."
+    "Enable building examples. Default: ${PROJECT_IS_TOP_LEVEL}. Values: { ON, OFF }."
     ${PROJECT_IS_TOP_LEVEL}
 )
 


### PR DESCRIPTION
Update the documentation of **[CMAKE.SKIP_TESTS]** and **[CMAKE.SKIP_EXAMPLES]** to match [how we implement them in Exemplar](https://github.com/bemanproject/exemplar/blob/0a275deb116a07d97dc197c8eda5ff74832e356b/CMakeLists.txt#L13-L25), using `${PROJECT_IS_TOP_LEVEL}` for the default value. This is correct IMHO, as it provides a correct documentation string in the CMakeCache when using the library as a sub-project.