### PR TITLE
Update Beman Standard: drop the @bemanproject/core-reviewers team

### DIFF
--- a/docs/BEMAN_STANDARD.md
+++ b/docs/BEMAN_STANDARD.md
@@ -105,7 +105,7 @@ Bad examples: `smartpointer` or `optional26`.
 
 ### **[REPOSITORY.CODEOWNERS]**
 
-**REQUIREMENT**: There must be a `.github/CODEOWNERS` file with a relevant set of codeowners, starting with the local codeowners and ending with [@bemanproject/core-reviewers](https://github.com/orgs/bemanproject/teams/core-reviewers) (a group of Beman regulars who offered to help generally with code reviews).  Please check [exemplar: CODEOWNERS](https://github.com/bemanproject/exemplar/blob/main/.github/CODEOWNERS).
+**REQUIREMENT**: There must be a `.github/CODEOWNERS` file with a relevant set of codeowners. Please check [exemplar: CODEOWNERS](https://github.com/bemanproject/exemplar/blob/main/.github/CODEOWNERS).
 
 ### **[REPOSITORY.DISALLOW_GIT_SUBMODULES]**
 


### PR DESCRIPTION
Update Beman Standard: drop the @bemanproject/core-reviewers team as decided at last Beman Weekly sync