### PR TITLE
Update Beman Standard: README.PURPOSE lines should be parsed automatically

### DIFF
--- a/docs/BEMAN_STANDARD.md
+++ b/docs/BEMAN_STANDARD.md
@@ -264,7 +264,8 @@ If the library has been deployed onto Compiler Explorer, add this badge and repl
 
 ### **[README.PURPOSE]**
 
-**RECOMMENDATION**: Following the badges list and a newline, the `README.md` should contain a one line summary describing the library's purpose.
+**RECOMMENDATION**: Following the badges list and a newline,
+the `README.md` should contain a one line summary describing the library's purpose.
 
 Use the following style:
 
@@ -275,7 +276,9 @@ Use the following style:
 ### **[README.IMPLEMENTS]**
 
 **RECOMMENDATION**: Following the purpose and a newline, the
-`README.md` should indicate which papers the repository implements. Use the following style:
+`README.md` should indicate which papers the repository implements.
+
+Use the following style:
 
 ```markdown
 **Implements**: [`std::optional<T&>` (P2988R5)](https://wg21.link/P2988R5) and

--- a/docs/BEMAN_STANDARD.md
+++ b/docs/BEMAN_STANDARD.md
@@ -266,6 +266,12 @@ If the library has been deployed onto Compiler Explorer, add this badge and repl
 
 **RECOMMENDATION**: Following the badges list and a newline, the `README.md` should contain a one line summary describing the library's purpose.
 
+Use the following style:
+
+```markdown
+**Purpose**: This repository implements `std::optional` extensions targeting C++26. The `beman.optional` library aims to evaluate the stability, the usability, and the performance of these proposed changes before they are officially adopted by WG21 into the C++ Working Draft. Additionally, it allows developers to use these new features before they are implemented in major standard library compilers.
+```
+
 ### **[README.IMPLEMENTS]**
 
 **RECOMMENDATION**: Following the purpose and a newline, the


### PR DESCRIPTION
Update Beman Standard: README.PURPOSE lines should be parsed automatically

Note: I didn't change `README.PURPOSE` rule content. I just provided a formatting example to follow, and which is easy to implement in beman-tidy.