### PR TITLE
Update Beman Standard: extend README.BADGES with Standard Target entries

### DIFF
--- a/docs/BEMAN_STANDARD.md
+++ b/docs/BEMAN_STANDARD.md
@@ -262,6 +262,18 @@ or
 ![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_retired.svg)
 ```
 
+Use exactly one of the following entries for the standard target status badge:
+
+```markdown
+![Standard Target](https://github.com/bemanproject/beman/blob/main/images/badges/cpp26.svg)
+```
+
+or
+
+```markdown
+![Standard Target](https://github.com/bemanproject/beman/blob/main/images/badges/cpp29.svg)
+```
+
 If the library has been deployed onto Compiler Explorer, add this badge and replace the link with the link of the example code taken from Compiler Explorer:
 
 ```markdown


### PR DESCRIPTION
Update Beman Standard: extend README.BADGES with Standard Target entries as introduced in https://github.com/bemanproject/beman/pull/128 by @JeffGarland 

Note: This NOT change README.BADGES actual status, just require one more badge to have it. I will incorporate this new behaviour in https://github.com/bemanproject/infra/issues/51, if this PR is approved.

Examples
- https://github.com/bemanproject/optional/pull/133
- https://github.com/bemanproject/exemplar/pull/198