### PR TITLE
Update The Beman Standard: DIRECTORY.SOURCES should be a REQUIREMENT

### DIFF
--- a/docs/BEMAN_STANDARD.md
+++ b/docs/BEMAN_STANDARD.md
@@ -543,7 +543,7 @@ include
 
 ### **[DIRECTORY.SOURCES]**
 
-**RECOMMENDATION**: Sources and headers not part of the
+**REQUIREMENT**: If present, sources and headers not part of the
 public interface should reside in the top-level `src/` directory, and should use
 the same structure from `include/` - e.g., `src/beman/<short_name>/`. Check `CMAKE.AVOID_PASSTHROUGHS`.
 


### PR DESCRIPTION
Checked:
- [DIRECTORY.INTERFACE_HEADERS](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md#directoryinterface_headers) and [DIRECTORY.IMPLEMENTATION_HEADERS](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md#directoryimplementation_headers) are REQUIREMENTS, no conditional.
- DIRECTORY.SOURCES becomes a REQUIREMENT with conditional (`if present`)
- [DIRECTORY.TESTS](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md#directorytests) REQUIREMENT with NO conditional. We should always have tests!
- [DIRECTORY.EXAMPLES](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md#directorytests) , [DIRECTORY.DOCS](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md#directoryexamples) and [DIRECTORY.PAPERS](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md#directoryexamples) are REQUIREMENTS with conditional. 


TLDR: DIRECTORY.IMPLEMENTATION_HEADERS, DIRECTORY.SOURCES, DIRECTORY.EXAMPLES, DIRECTORY.DOCS, DIRECTORY.PAPERS cannot be included in beman-tidy. We can check for these rules, but if we don't find corresponding directories, we cannot fail the linting, because we cannot know if there was another convention used or the directory was missing.

TODOs for `beman-tidy` - full implemention `DIRECTORY.INTERFACE_HEADERS` and `DIRECTORY.TESTS` only.
We can try to give warning for other DIRECTORY.* rules, but never fail the pass (not even for `--require-all`).