### PR TITLE
Update The Beman Standard: DIRECTORY.EXAMPLES is actually non-conditional

### DIFF
--- a/docs/BEMAN_STANDARD.md
+++ b/docs/BEMAN_STANDARD.md
@@ -597,7 +597,7 @@ tests
 
 ### **[DIRECTORY.EXAMPLES]**
 
-**REQUIREMENT**: If present, all example files must reside within the top-level `examples/`
+**REQUIREMENT**: All example files must reside within the top-level `examples/`
 directory. Each project must have at least one relevant example.
 
 Examples:


### PR DESCRIPTION
Update The Beman Standard: DIRECTORY.EXAMPLES is actually non-conditional, considering that we already require "Each project must have at least one relevant example." -> the `examples/` directory is not optional.

IMO, there is no actual change over the standard, it just makes things easier to use.