### PR TITLE
Update The Beman Standard: DIRECTORY.TESTS is now explicit

### DIFF
--- a/docs/BEMAN_STANDARD.md
+++ b/docs/BEMAN_STANDARD.md
@@ -569,7 +569,8 @@ src
 
 **REQUIREMENT**: All test files must reside within the top-level `tests/`
 directory, and should use the same structure from `include/`. If multiple test types are present,
-subdirectories can be made (e.g., unit tests, performance etc).
+subdirectories can be made (e.g., unit tests, performance etc). Each project must have at least
+one relevant test.
 
 Examples:
 


### PR DESCRIPTION
Update The Beman Standard: DIRECTORY.TESTS is now explicit - we do require to have tests, similar to DIRECTORY.EXAMPLES.

IMO, there is no change in the standard after this PR, we just makes things easier to use.