### PR TITLE
Remove formatting rules from [LICENSE.APPROVED] and add [README.LICENSE] rule

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,3 @@
-==============================================================================
-The Beman Project is under the Apache License v2.0 with LLVM Exceptions:
-==============================================================================
 
                                  Apache License
                            Version 2.0, January 2004
@@ -220,15 +217,3 @@ conflicts with the conditions of the GPLv2, you may retroactively and
 prospectively choose to deem waived or otherwise exclude such Section(s) of
 the License, but only in their entirety and only with respect to the Combined
 Software.
-
-==============================================================================
-Software from third parties included in the Beman Project:
-==============================================================================
-The Beman Project contains third party software which is under different license
-terms. All such code will be identified clearly using at least one of two
-mechanisms:
-1) It will be in a separate directory tree with its own `LICENSE.txt` or
-   `LICENSE` file at the top containing the specific license and restrictions
-   which apply to that software, or
-2) It will contain specific license and restriction terms at the top of every
-   file.

--- a/docs/BEMAN_STANDARD.md
+++ b/docs/BEMAN_STANDARD.md
@@ -66,35 +66,6 @@ recommendations.
 2. [Boost Software License 1.0](https://www.boost.org/LICENSE_1_0.txt)
 3. [The MIT License](https://opensource.org/license/mit)
 
-Use the following format:
-
-```markdown
-==============================================================================
-The Beman Project is under the Apache License v2.0 with LLVM Exceptions:
-==============================================================================
-
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
-
-... // actual license content
-
-==============================================================================
-Software from third parties included in the Beman Project:
-==============================================================================
-The Beman Project contains third party software which is under different license
-terms. All such code will be identified clearly using at least one of two
-mechanisms:
-1) It will be in a separate directory tree with its own `LICENSE.txt` or
-   `LICENSE` file at the top containing the specific license and restrictions
-   which apply to that software, or
-2) It will contain specific license and restriction terms at the top of every
-   file.
-
-```
-
-Check [LICENSE.APACHE_LLVM](#licenseapache_llvm) for recommended license format.
-
 ### **[LICENSE.APACHE_LLVM]**
 
 **RECOMMENDATION**: A Beman library should be licensed
@@ -352,6 +323,49 @@ or
 
 ```markdown
 **Status**: [Retired. No longer maintained or actively developed.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#retired-no-longer-maintained-or-actively-developed)
+```
+
+### **[README.LICENSE]**
+
+**REQUIREMENT**: Following the library status line and a new line, the `README.md` must have a `LICENSE` section.
+
+Use exactly the following format:
+```markdown
+## License
+
+beman.exemplar is licensed under the Apache License v2.0 with LLVM Exceptions.
+
+<!-- Other optional mentions go on this line ... >
+```
+
+or
+
+```markdown
+## License
+
+beman.exemplar is licensed under the Boost Software License 1.0.
+
+<!-- Other optional mentions go on this line ... >
+```
+
+or
+
+```markdown
+## License
+
+beman.exemplar is licensed under the MIT License.
+
+<!-- Other optional mentions go on this line ... >
+```
+
+or
+
+```markdown
+## License
+
+beman.exemplar is licensed under the Boost Software License 1.0 and under the ... .
+
+<!-- Other optional mentions go on this line ... >
 ```
 
 ## CMake


### PR DESCRIPTION
After a discussion at the weekly sync meeting, we decided that the header and footer required by [LICENSE.APPROVED] were superfluous and potentially misleading, since it stated that "The Beman Project is under the Apache License v2.0 with LLVM Exceptions" but projects were not required to use that license.

To ensure users are properly informed about the project's license after the removal of that header, this commit also adds a new rule requiring the project's README file to specify the license used by the project.