### PR TITLE
Remove usage of STATIC in beman standard

### DIFF
--- a/docs/BEMAN_STANDARD.md
+++ b/docs/BEMAN_STANDARD.md
@@ -444,7 +444,7 @@ be identical to the library name.
 Examples:
 
 ```CMake
-add_library(beman.smart_pointer STATIC)
+add_library(beman.smart_pointer)
 #...
 ```
 


### PR DESCRIPTION
Fixes #93. The change was already made to exemplar.