### PR TITLE
Fix URLs after doc filenames were changed to be lowercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ### Mission
 
-The Beman Project’s [mission](docs/MISSION.md) is to **support the efficient design and adoption of the highest quality C++ standard libraries** through implementation experience, user feedback, and technical expertise.
+The Beman Project's [mission](/docs/mission.md) is to **support the efficient design and adoption of the highest quality C++ standard libraries** through implementation experience, user feedback, and technical expertise.
 
 ### Community
 
@@ -18,7 +18,7 @@ And we want to make it easy for the C++ community to use these libraries to ensu
 
 ### Governance
 
-This project is organized by our [Governance structure](docs/GOVERNANCE.md).
+This project is organized by our [Governance](/docs/governance.md) structure.
 
 ### Participating and contributing
 
@@ -31,13 +31,13 @@ If you are looking for ways to contribute code, see the open issues of [bemanpro
 The [beman repository's issue list](https://github.com/bemanproject/beman/issues), in particular, has implementation requests for various papers.
 Issues marked with `good first issue` are perfect for new contributors and usually have an assigned mentor. Don't hesitate to post on discourse with any questions.
 
-Please refer to our [code of conduct](/docs/CODE_OF_CONDUCT.md) and the [Beman standard](/docs/BEMAN_STANDARD.md) for further information about the community and
+Please refer to our [Code of Conduct](/docs/code_of_conduct.md) and the [Beman Standard](/docs/beman_standard.md) for further information about the community and
 development guidelines.
 
 ### FAQ
 
 Questions?
-Maybe they have already been answered in our [FAQ](docs/FAQ.md).
+Maybe they have already been answered in our [FAQ](/docs/faq.md).
 
 ### About the Name
 
@@ -45,4 +45,4 @@ The Beman project is named in memory of Beman Dawes - co-founder of [Boost](http
 
 ### Documentation
 
-The Beman Project has a variety of documentation available in the [docs/](./docs/) directory of this repository.
+The Beman Project has a variety of documentation available in the [docs/](/docs/) directory of this repository.

--- a/docs/beman_library_maturity_model.md
+++ b/docs/beman_library_maturity_model.md
@@ -36,8 +36,8 @@ These libraries were archived and no longer maintained. These libraries are not 
 
 Transition examples:
 
-* They were [Production ready. Stable API.](./BEMAN_LIBRARY_MATURITY_MODEL.md#production-ready-stable-api) at some point, but are no longer developed or maintained, being superseded by native compiler implementations - `Mature retirement`.
+* They were [Production ready. Stable API.](./beman_library_maturity_model.md#production-ready-stable-api) at some point, but are no longer developed or maintained, being superseded by native compiler implementations - `Mature retirement`.
 
-* They were [Production ready. API may undergo changes.](./BEMAN_LIBRARY_MATURITY_MODEL.md#production-ready-api-may-undergo-changes) at some point, but are no longer developed or maintained, being rejected from the ISO C+ Standardization - `Early retirement`.
+* They were [Production ready. API may undergo changes.](./beman_library_maturity_model.md#production-ready-api-may-undergo-changes) at some point, but are no longer developed or maintained, being rejected from the ISO C+ Standardization - `Early retirement`.
 
-* They were [Under development and not yet ready for production use.](./BEMAN_LIBRARY_MATURITY_MODEL.md#under-development-and-not-yet-ready-for-production-use) at some point and were abandoned - `Early retirement`.
+* They were [Under development and not yet ready for production use.](./beman_library_maturity_model.md#under-development-and-not-yet-ready-for-production-use) at some point and were abandoned - `Early retirement`.

--- a/docs/beman_standard.md
+++ b/docs/beman_standard.md
@@ -167,7 +167,7 @@ Known exceptions:
 
    2.1. An "About" section describing the main purpose and impact of the release.
 
-   2.2. A "Release Maturity" section indicating the current status of the library according to the [Beman Library Maturity Model](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md).
+   2.2. A "Release Maturity" section indicating the current status of the library according to the [Beman Library Maturity Model](https://github.com/bemanproject/beman/blob/main/docs/beman_library_maturity_model.md).
 
    2.3. A "Changelog" section listing all changes, organized by:
    - Breaking changes (if any)
@@ -193,7 +193,7 @@ Use the following format:
 
 <!-- TODO: Update this section and remove this comment. -->
 
-This release has a status of [Under development and not yet ready for production use.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#under-development-and-not-yet-ready-for-production-use).
+This release has a status of [Under development and not yet ready for production use.](https://github.com/bemanproject/beman/blob/main/docs/beman_library_maturity_model.md#under-development-and-not-yet-ready-for-production-use).
 
 
 ## Changelog
@@ -327,30 +327,30 @@ If the library has been deployed onto Compiler Explorer, add this badge and repl
 
 ### **[readme.library_status]**
 
-**REQUIREMENT**: Following the implements section and a newline, the `README.md` must indicate the **current** library status with respect to the [Beman library maturity model](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md). An extra badge must be added to the `README.md` to visually indicate the library status (check `[readme.badges]`). Note: The full library status history can be found in the GitHub release notes.
+**REQUIREMENT**: Following the implements section and a newline, the `README.md` must indicate the **current** library status with respect to the [Beman library maturity model](https://github.com/bemanproject/beman/blob/main/docs/beman_library_maturity_model.md). An extra badge must be added to the `README.md` to visually indicate the library status (check `[readme.badges]`). Note: The full library status history can be found in the GitHub release notes.
 
 Use exactly one of the following entries for the status line:
 
 ```markdown
-**Status**: [Under development and not yet ready for production use.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#under-development-and-not-yet-ready-for-production-use)
+**Status**: [Under development and not yet ready for production use.](https://github.com/bemanproject/beman/blob/main/docs/beman_library_maturity_model.md#under-development-and-not-yet-ready-for-production-use)
 ```
 
 or
 
 ```markdown
-**Status**: [Production ready. API may undergo changes.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#production-ready-api-may-undergo-changes)
+**Status**: [Production ready. API may undergo changes.](https://github.com/bemanproject/beman/blob/main/docs/beman_library_maturity_model.md#production-ready-api-may-undergo-changes)
 ```
 
 or
 
 ```markdown
-**Status**: [Production ready. Stable API.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#production-ready-stable-api)
+**Status**: [Production ready. Stable API.](https://github.com/bemanproject/beman/blob/main/docs/beman_library_maturity_model.md#production-ready-stable-api)
 ```
 
 or
 
 ```markdown
-**Status**: [Retired. No longer maintained or actively developed.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#retired-no-longer-maintained-or-actively-developed)
+**Status**: [Retired. No longer maintained or actively developed.](https://github.com/bemanproject/beman/blob/main/docs/beman_library_maturity_model.md#retired-no-longer-maintained-or-actively-developed)
 ```
 
 ### **[readme.license]**

--- a/docs/code_of_conduct.md
+++ b/docs/code_of_conduct.md
@@ -116,7 +116,7 @@ If you have questions, please feel free to ask on our communication channels, or
 
 ## Conduct team
 
-The conduct team will be the Beman Project Leads as outlined in our [Governance Documents](GOVERNANCE.md).
+The conduct team will be the Beman Project Leads as outlined in our [Governance Documents](governance.md).
 
 ### Reporting conduct
 
@@ -192,7 +192,7 @@ If that’s the case, the identities of anyone involved will remain confidential
 ### Appealing
 
 Only permanent resolutions, such as bans, or requests for public actions may be appealed. 
-To appeal a decision of the conduct team, contact the [Beman leads](GOVERNANCE.md) with your appeal and they will review the case.
+To appeal a decision of the conduct team, contact the [Beman leads](governance.md) with your appeal and they will review the case.
 
 In general, it is **not** appropriate to appeal a particular decision in public
 areas of GitHub or Discord. 

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -67,7 +67,7 @@ Beman Project Leads ultimately decide the direction of the Project.
 
 # 5. Code of Conduct
 
-Please refer to our [Code of Conduct](CODE_OF_CONDUCT.md).
+Please refer to our [Code of Conduct](./code_of_conduct.md).
 
 # 5.1 Respectful Behavior:
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -6,9 +6,9 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 This directory contains information about how the project works, goals, and community information.
 
-- [BEMAN_LIBRARY_MATURITY_MODEL.md](./BEMAN_LIBRARY_MATURITY_MODEL.md): The `Beman library maturity model` describes the lifetime of libraries inside the Beman Project.
-- [BEMAN_STANDARD.md](./BEMAN_STANDARD.md): The `Beman Standard` is a set of development guidelines for the Beman Project.
-- [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md): The Beman Project's code of conduct.
-- [FAQ.md](./FAQ.md): Frequently asked questions about the Beman Project.
-- [GOVERNANCE.md](./GOVERNANCE.md): The governance document outlines the structure of the Beman Project.
-- [MISSION.md](./MISSION.md): The mission statement of the Beman Project.
+- [beman_library_maturity_model.md](./beman_library_maturity_model.md): The `Beman library maturity model` describes the lifetime of libraries inside the Beman Project.
+- [beman_standard.md](./beman_standard.md): The `Beman Standard` is a set of development guidelines for the Beman Project.
+- [code_of_conduct.md](./code_of_conduct.md): The Beman Project's code of conduct.
+- [faq.md](./faq.md): Frequently asked questions about the Beman Project.
+- [governance.md](./governance.md): The governance document outlines the structure of the Beman Project.
+- [mission.md](./mission.md): The mission statement of the Beman Project.

--- a/guidelines/code-review.md
+++ b/guidelines/code-review.md
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 The following documents code review processes for the Beman Project organization.
 
-* As stated in [repository.codeowners](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md#repositorycodeowners), a list of local reviewers is available for each repository, and automated code review rules are enforced via [repository.code_review_rules](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md#repositorycode_review_rules).
+* As stated in [repository.codeowners](https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md#repositorycodeowners), a list of local reviewers is available for each repository, and automated code review rules are enforced via [repository.code_review_rules](https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md#repositorycode_review_rules).
 
 * By default, all PRs are reviewed by at least one code owner.
 


### PR DESCRIPTION
Issue #159 

Fix URLs after doc filenames were changed to be lowercase. Follow-up PR after #170 . I had to split the change in to 2 PRs, because GitHub diff mode will not properly display changes if I have both file renaming and file content changes. (I made admin merge for #170 ).