### PR TITLE
SPDX requirement: "first possible line" -> "first 25 lines"

### DIFF
--- a/docs/beman_standard.md
+++ b/docs/beman_standard.md
@@ -789,8 +789,7 @@ Examples: `identity.test.cpp`, `optional_ref.test.cpp` or `optional_range_suppor
 
 ### **[file.license_id]**
 
-**Requirement**: The [SPDX license identifier](https://spdx.dev/learn/handling-license-info/) must be added at the
-first possible line in all files which can contain a comment
+**Requirement**: The [SPDX license identifier](https://spdx.dev/learn/handling-license-info/) must be added within the first 25 lines in all files which can contain a comment
 (e.g., C++, scripts, CMake/Makefile, YAML/YML, JASON, XML, HTML, LaTeX, Dockerfile etc).
 
 Examples:


### PR DESCRIPTION
Based on feedback from Steve Downey @steve-downey on Discourse:

    Checking the exact first line is far too strict. It should be in the first few lines, although most scanning tools do not actually care.
    Common examples put file identification and copyright info ahead of the SPDX comment.

https://discourse.bemanproject.org/t/beman-tidy-spdx-license-identifier-check-is-too-strict-in-0-4-1/583